### PR TITLE
fix: Resolve JSX syntax errors by adding React imports

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 
 interface FormData {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Link from 'next/link'
 
 const Footer = () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import React, { useState } from 'react'
 import Link from 'next/link'
 
 const Header = () => {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
 

--- a/src/components/Solutions.tsx
+++ b/src/components/Solutions.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { motion } from 'framer-motion'
 import Link from 'next/link'
 


### PR DESCRIPTION
Fix JSX syntax errors in all component files

## Problem
The application was failing to compile with the error:
```
Unexpected token `section`. Expected jsx identifier
```

## Solution
Added explicit React imports to all component files:
- Hero.tsx
- Header.tsx
- Solutions.tsx
- Contact.tsx
- Footer.tsx

## Technical Details
- Next.js 13+ with TypeScript requires explicit React imports for JSX
- TSConfig `jsx: "preserve"` setting needed manual React imports
- All components now properly import React and hooks as needed

The application should now build and run without syntax errors.

Generated with [Claude Code](https://claude.ai/code)